### PR TITLE
fix: temporary file pattern to prevent race condition between async save and player join

### DIFF
--- a/src/main/java/jp/azisaba/lgw/ecplus/InventoryData.java
+++ b/src/main/java/jp/azisaba/lgw/ecplus/InventoryData.java
@@ -63,6 +63,12 @@ public class InventoryData {
     private boolean loadLegacyYaml() {
         File file = new File(EnderChestPlus.getInventoryDataFile(), uuid + ".yml");
         if (!file.isFile()) return false;
+
+        // 前回のクラッシュなどで残った .tmp ファイルを後片付けする
+        File staleTmp = new File(file.getAbsolutePath() + ".tmp");
+        if (staleTmp.exists()) {
+            staleTmp.delete();
+        }
         YamlConfiguration config = YamlConfiguration.loadConfiguration(file);
         for (String pageKey : config.getKeys(false)) {
             int page = positiveInt(pageKey);


### PR DESCRIPTION
## 概要

非同期セーブとプレイヤー参加時の読み込みレースコンディションを修正します。

## 修正内容

MySQL 移行済みのコードベースに合わせて、`loadLegacyYaml()` に stale `.tmp` ファイルのクリーンアップ処理を追加しました。

- 以前のバージョン（YAML 保存時代）でクラッシュが発生した際に残った `.tmp` ファイルを、レガシーデータ読み込み前に削除します
- これにより、書き込み途中のファイルを読み込んで `InvalidConfigurationException` が発生する問題を防止します

## 関連

元の fix commit: `129e9d2` (fix/race-parsing ブランチ)